### PR TITLE
allow all versions of react after react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webgl"
   ],
   "peerDependencies": {
-    "react": "^16.0"
+    "react": ">=16.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- change peer-dependency `react` to accept versions after `16.0` as `>=16.0`
- this will prevent errors at install