### PR TITLE
Feature/update annotation resizing

### DIFF
--- a/examples/annotations/index.ts
+++ b/examples/annotations/index.ts
@@ -65,7 +65,7 @@ const createPersonStyle = (radius: number): Graph.NodeStyle => ({
 
 let annotations = [{
   type: 'text' as const,
-  id: 'test-text-annotation',
+  id: '1',
   width: 100,
   height: 100,
   x: -400,
@@ -86,7 +86,7 @@ let annotations = [{
   }
 }, {
   type: 'text' as const,
-  id: 'test-text-annotation-2',
+  id: '2',
   width: 100,
   height: 100,
   x: -600,
@@ -235,7 +235,7 @@ const renderOptions: WebGL.Options = {
     edges = edges.map((edge) => (edge.id === id ? { ...edge, style: { ...edge.style, width: 1 } } : edge))
     render({ nodes, edges, annotations, options: renderOptions })
   },
-  onAnnotationDrag: ({ annotationX, annotationY, target: { id, x = 0, y = 0 } }: WebGL.AnnotationDragEvent) => {
+  onAnnotationDrag: ({ annotationX, annotationY, target: { id, x = 0, y = 0 } }: WebGL.AnnotationDragEvent) => {    
     const dx = annotationX - x
     const dy = annotationY - y
 
@@ -247,7 +247,9 @@ const renderOptions: WebGL.Options = {
 
     render({ nodes, edges, annotations, options: renderOptions })
   },
-  onAnnotationResize: ({ x, y, width, height, target: { id } }: WebGL.AnnotationResizeEvent) => {
+  onAnnotationResize: ({ position, x, y, width, height, target: { id } }: WebGL.AnnotationResizeEvent) => {
+    renderOptions.cursor = `${position}-resize`
+
     annotations = annotations.map((annotation) => (
       annotation.id === id ? (
         { ...annotation, x, y, width, height }

--- a/examples/annotations/index.ts
+++ b/examples/annotations/index.ts
@@ -247,10 +247,10 @@ const renderOptions: WebGL.Options = {
 
     render({ nodes, edges, annotations, options: renderOptions })
   },
-  onAnnotationResize: ({ width, height, target: { id, x = 0, y = 0 } }: WebGL.AnnotationResizeEvent) => {
+  onAnnotationResize: ({ x, y, width, height, target: { id } }: WebGL.AnnotationResizeEvent) => {
     annotations = annotations.map((annotation) => (
       annotation.id === id ? (
-        { ...annotation, width, height }
+        { ...annotation, x, y, width, height }
       ) : annotation
     ))
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint \"src/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/**.{ts,tsx}\" --fix",
     "perf": "parcel perf/index.html",
     "build:tsc": "tsc --project ./tsconfig.json",
     "build:umd": "parcel build src/index.umd.ts --out-file dist/index.umd.min.js --global trellis",

--- a/src/renderers/webgl/annotations/rectangle.ts
+++ b/src/renderers/webgl/annotations/rectangle.ts
@@ -2,48 +2,11 @@ import * as PIXI from 'pixi.js-legacy'
 import { InternalRenderer } from '..'
 import { RectangleAnnotation } from '../../..'
 import { clientPositionFromEvent, colorToNumber, pointerKeysFromEvent } from '../utils'
-
-
-const DEFAULT_FILL = '#FFFFFF'
-const DEFAULT_STROKE = '#000000'
+import { DEFAULT_FILL, DEFAULT_STROKE, ResizeHitBox, getHitBoxOrigin, RESIZE_RADIUS } from './utils'
 
 const MIN_WIDTH = 5
 const MIN_HEIGHT = 5
-
-// const HIT_AREA_PADDING = 10
-const RESIZE_RADIUS = 4
-
-type ResizeHitBox = {
-  graphic: PIXI.Graphics
-  position: 'nw' | 'ne' | 'sw' | 'se'
-}
-
-const getHitBoxOrigin = (hitBox: ResizeHitBox, rectOrigin: { x: number, y: number }, width: number, height: number): [x: number, y: number] | undefined => {
-  switch(hitBox.position) {
-    case 'nw' :
-      return [rectOrigin.x, rectOrigin.y]
-    case 'sw':
-      return [rectOrigin.x, rectOrigin.y + height]
-    case 'ne':
-      return [rectOrigin.x + width, rectOrigin.y]
-    case 'se':
-      return [rectOrigin.x + width, rectOrigin.y + height]
-  }
-}
-
-// const getHitArea = (annotation: RectangleAnnotation) => {
-//   const topLeft = [annotation.x - HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
-//   const bottomLeft = [annotation.x - HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
-//   const topRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
-//   const bottomRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
-
-//   return [
-//     ...topLeft,
-//     ...bottomLeft,
-//     ...bottomRight,
-//     ...topRight
-//   ]
-// }
+// TODO: do we want pointerEnter/Leave events for the resize circles?
 export class RectangleAnnotationRenderer {
 
   x: number
@@ -313,20 +276,6 @@ export class RectangleAnnotationRenderer {
     this.renderer.onAnnotationPointerLeave?.({ type: 'annotationPointer', x, y, clientX: client.x, clientY: client.y, target: this.annotation, ...pointerKeysFromEvent(event.data.originalEvent) })
   }
 
-  // TODO: do we want pointerEnter/Leave events for the resize circles?
-  // private resizePointerEnter = (event: PIXI.InteractionEvent) => {
-  //   if (this.renderer.hoveredAnnotation === this || this.renderer.clickedAnnotation !== undefined || this.renderer.dragging) return
-
-  //   this.renderer.hoveredAnnotation = this
-
-  //   this.dirty = true
-  //   this.renderer.dirty = true
-
-  //   const { x, y } = this.renderer.root.toLocal(event.data.global)
-  //   const client = clientPositionFromEvent(event.data.originalEvent)
-  //   this.renderer.onAnnotationPointerEnter?.({ type: 'annotationPointer', x, y, clientX: client.x, clientY: client.y, target: this.annotation, ...pointerKeysFromEvent(event.data.originalEvent) })
-  // }
-
   private resizePointerDown = (hitBoxIdx: number) => (_: PIXI.InteractionEvent) => {
 
     this.resizeClicked = this.resizeHitBoxes[hitBoxIdx]
@@ -427,19 +376,6 @@ export class RectangleAnnotationRenderer {
 
     return
   }
-
-  // private resizePointerLeave = (event: PIXI.InteractionEvent) => {
-  //   if (this.renderer.clickedAnnotation !== undefined || this.renderer.hoveredAnnotation !== this || this.renderer.dragging) return
-
-  //   this.renderer.hoveredAnnotation = undefined
-
-  //   this.dirty = true
-  //   this.renderer.dirty = true
-
-  //   const { x, y } = this.renderer.root.toLocal(event.data.global)
-  //   const client = clientPositionFromEvent(event.data.originalEvent)
-  //   this.renderer.onAnnotationPointerLeave?.({ type: 'annotationPointer', x, y, clientX: client.x, clientY: client.y, target: this.annotation, ...pointerKeysFromEvent(event.data.originalEvent) })
-  // }
 
   private clearDoubleClick() {
     this.doubleClickTimeout = undefined

--- a/src/renderers/webgl/annotations/text.ts
+++ b/src/renderers/webgl/annotations/text.ts
@@ -2,47 +2,12 @@ import * as PIXI from 'pixi.js-legacy'
 import { InternalRenderer } from '..'
 import { TextAnnotation } from '../../..'
 import { clientPositionFromEvent, colorToNumber, pointerKeysFromEvent } from '../utils'
+import { DEFAULT_FILL, DEFAULT_STROKE, ResizeHitBox, getHitBoxOrigin, RESIZE_RADIUS } from './utils'
 
 
-
-const DEFAULT_FILL = '#FFFFFF'
-const DEFAULT_STROKE = '#000000'
 const DEFAULT_PADDING = 4
 
-// const HIT_AREA_PADDING = 10
-const RESIZE_RADIUS = 4
-
-type ResizeHitBox = {
-  graphic: PIXI.Graphics
-  position: 'nw' | 'ne' | 'sw' | 'se'
-}
-
-const getHitBoxOrigin = (hitBox: ResizeHitBox, rectOrigin: { x: number, y: number }, width: number, height: number): [x: number, y: number] | undefined => {
-  switch(hitBox.position) {
-    case 'nw' :
-      return [rectOrigin.x, rectOrigin.y]
-    case 'sw':
-      return [rectOrigin.x, rectOrigin.y + height]
-    case 'ne':
-      return [rectOrigin.x + width, rectOrigin.y]
-    case 'se':
-      return [rectOrigin.x + width, rectOrigin.y + height]
-  }
-}
-
-// const getHitArea = (annotation: TextAnnotation) => {
-//   const topLeft = [annotation.x - HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
-//   const bottomLeft = [annotation.x - HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
-//   const topRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
-//   const bottomRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
-
-//   return [
-//     ...topLeft,
-//     ...bottomLeft,
-//     ...bottomRight,
-//     ...topRight
-//   ]
-// }
+// TODO: do we want pointerEnter/Leave events for the resize circles?
 export class TextAnnotationRenderer {
 
   x: number

--- a/src/renderers/webgl/annotations/utils.ts
+++ b/src/renderers/webgl/annotations/utils.ts
@@ -13,14 +13,14 @@ export type ResizeHitBox = {
 
 export const getHitBoxOrigin = (hitBox: ResizeHitBox, rectOrigin: { x: number, y: number }, width: number, height: number): [x: number, y: number] | undefined => {
   switch(hitBox.position) {
-    case 'nw' :
-      return [rectOrigin.x, rectOrigin.y]
-    case 'sw':
-      return [rectOrigin.x, rectOrigin.y + height]
-    case 'ne':
-      return [rectOrigin.x + width, rectOrigin.y]
-    case 'se':
-      return [rectOrigin.x + width, rectOrigin.y + height]
+  case 'nw' :
+    return [rectOrigin.x, rectOrigin.y]
+  case 'sw':
+    return [rectOrigin.x, rectOrigin.y + height]
+  case 'ne':
+    return [rectOrigin.x + width, rectOrigin.y]
+  case 'se':
+    return [rectOrigin.x + width, rectOrigin.y + height]
   }
 }
 

--- a/src/renderers/webgl/annotations/utils.ts
+++ b/src/renderers/webgl/annotations/utils.ts
@@ -1,0 +1,39 @@
+import * as PIXI from 'pixi.js-legacy'
+
+export const DEFAULT_FILL = '#FFFFFF'
+export const DEFAULT_STROKE = '#000000'
+
+// export const HIT_AREA_PADDING = 10
+export const RESIZE_RADIUS = 4
+
+export type ResizeHitBox = {
+  graphic: PIXI.Graphics
+  position: 'nw' | 'ne' | 'sw' | 'se'
+}
+
+export const getHitBoxOrigin = (hitBox: ResizeHitBox, rectOrigin: { x: number, y: number }, width: number, height: number): [x: number, y: number] | undefined => {
+  switch(hitBox.position) {
+    case 'nw' :
+      return [rectOrigin.x, rectOrigin.y]
+    case 'sw':
+      return [rectOrigin.x, rectOrigin.y + height]
+    case 'ne':
+      return [rectOrigin.x + width, rectOrigin.y]
+    case 'se':
+      return [rectOrigin.x + width, rectOrigin.y + height]
+  }
+}
+
+// const getHitArea = (annotation: RectangleAnnotation) => {
+//   const topLeft = [annotation.x - HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
+//   const bottomLeft = [annotation.x - HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
+//   const topRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y - HIT_AREA_PADDING]
+//   const bottomRight = [annotation.x + annotation.width + HIT_AREA_PADDING, annotation.y + annotation.height + HIT_AREA_PADDING]
+
+//   return [
+//     ...topLeft,
+//     ...bottomLeft,
+//     ...bottomRight,
+//     ...topRight
+//   ]
+// }

--- a/src/renderers/webgl/index.ts
+++ b/src/renderers/webgl/index.ts
@@ -34,10 +34,13 @@ export type EdgePointerEvent = { type: 'edgePointer', x: number, y: number, clie
 export type AnnotationPointerEvent = { type: 'annotationPointer', x: number, y: number, clientX: number, clientY: number, target: Graph.Annotation, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
 
 
+export type AnnotationResizePointerEvent = { type: 'annotationPointer', position: 'nw' | 'ne' | 'se' | 'sw', x: number, y: number, clientX: number, clientY: number, target: Graph.Annotation, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
+
+
 export type AnnotationDragEvent = { type: 'annotationDrag',  x: number, y: number, clientX: number, clientY: number, annotationX: number, annotationY: number,  target: Graph.Annotation, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
 
 
-export type AnnotationResizeEvent = { type: 'annotationResize',  x: number, y: number, width: number, height: number,  target: Graph.Annotation, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
+export type AnnotationResizeEvent = { type: 'annotationResize', position: 'nw' | 'ne' | 'se' | 'sw',  x: number, y: number, width: number, height: number,  target: Graph.Annotation, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
 
 
 export type ViewportPointerEvent = { type: 'viewportPointer', x: number, y: number, clientX: number, clientY: number, target: Graph.Viewport, altKey?: boolean, ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean }
@@ -70,6 +73,7 @@ export type Options<N extends Graph.Node = Graph.Node, E extends Graph.Edge = Gr
   edgesEqual?: (previous: E[], current: E[]) => boolean
   nodeIsEqual?: (previous: N, current: N) => boolean
   edgeIsEqual?: (previous: E, current: E) => boolean
+
   onNodePointerEnter?: (event: NodePointerEvent) => void
   onNodePointerDown?: (event: NodePointerEvent) => void
   onNodeDragStart?: (event: NodeDragEvent) => void
@@ -79,22 +83,31 @@ export type Options<N extends Graph.Node = Graph.Node, E extends Graph.Edge = Gr
   onNodeClick?: (event: NodePointerEvent) => void
   onNodeDoubleClick?: (event: NodePointerEvent) => void
   onNodePointerLeave?: (event: NodePointerEvent) => void
+
   onEdgePointerEnter?: (event: EdgePointerEvent) => void
   onEdgePointerDown?: (event: EdgePointerEvent) => void
   onEdgePointerUp?: (event: EdgePointerEvent) => void
   onEdgePointerLeave?: (event: EdgePointerEvent) => void
   onEdgeClick?: (event: EdgePointerEvent) => void
   onEdgeDoubleClick?: (event: EdgePointerEvent) => void
+
   onAnnotationPointerEnter?: (event: AnnotationPointerEvent) => void
   onAnnotationPointerDown?: (event: AnnotationPointerEvent) => void
   onAnnotationDragStart?: (event: AnnotationDragEvent) => void
   onAnnotationDrag?: (event: AnnotationDragEvent) => void
   onAnnotationDragEnd?: (event: AnnotationDragEvent) => void
-  onAnnotationResize?: (event: AnnotationResizeEvent) => void
   onAnnotationPointerUp?: (event: AnnotationPointerEvent) => void
   onAnnotationPointerLeave?: (event: AnnotationPointerEvent) => void
   onAnnotationClick?: (event: AnnotationPointerEvent) => void
   onAnnotationDoubleClick?: (event: AnnotationPointerEvent) => void
+  
+  onAnnotationResizePointerUp?: (event: AnnotationResizePointerEvent) => void
+  onAnnotationResizePointerLeave?: (event: AnnotationResizePointerEvent) => void
+  onAnnotationResize?: (event: AnnotationResizeEvent) => void
+  onAnnotationResizePointerEnter?: (event: AnnotationResizePointerEvent) => void
+  onAnnotationResizePointerDown?: (event: AnnotationResizePointerEvent) => void
+
+
   onViewportPointerEnter?: (event: ViewportPointerEvent) => void
   onViewportPointerDown?: (event: ViewportPointerEvent) => void
   onViewportPointerMove?: (event: ViewportPointerEvent) => void
@@ -146,6 +159,7 @@ export class InternalRenderer<N extends Graph.Node, E extends Graph.Edge>{
   viewportDirty = false
   time = performance.now()
   annotationsBottomLayer = new PIXI.Container()
+  annotationsLayer = new PIXI.Container()
   edgesLayer = new PIXI.Container()
   nodesLayer = new PIXI.Container()
   labelsLayer = new PIXI.Container()
@@ -266,9 +280,11 @@ export class InternalRenderer<N extends Graph.Node, E extends Graph.Edge>{
 
     this.labelsLayer.interactiveChildren = false
     this.nodesLayer.sortableChildren = true // TODO - perf test
+    this.annotationsBottomLayer.sortableChildren = true
 
     this.app.stage.addChild(this.root)
     this.root.addChild(this.annotationsBottomLayer)
+    this.root.addChild(this.annotationsLayer)
     this.root.addChild(this.edgesGraphic)
     this.root.addChild(this.edgesLayer)
     this.root.addChild(this.nodesLayer)


### PR DESCRIPTION
- Update how resizing works so that text/rectangle annotations can be resized via any of their vertices
- Added another container for annotations so there are now two `annotationsLayer` (top layer) and `annotationsBottomLayer` (bottom layer). This makes it so that when hovering over annotations the hovered annotation appears on top of the other(s). I just followed how we approached this with nodes/labels