### PR TITLE
Feature: support blob url for image renderer

### DIFF
--- a/src/renderers/image/index.ts
+++ b/src/renderers/image/index.ts
@@ -1,28 +1,70 @@
-import * as WebGL from '../webgl'
-import { Node, Edge, Annotation } from '../../'
-
+import * as WebGL from "../webgl";
+import { Node, Edge, Annotation } from "../../";
 
 export type Options = {
-  width?: number
-  height?: number
-  x?: number
-  y?: number
-  zoom?: number
-  resolution?: number
-  mimetype?: string
-}
-
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  zoom?: number;
+  resolution?: number;
+  mimetype?: string;
+};
 
 export const Renderer = <N extends Node, E extends Edge>() => {
-  return (graph: { nodes: N[], edges: E[], annotations?: Annotation[], options?: Options }) => {
-    const pixiRenderer = new WebGL.InternalRenderer({ container: document.createElement('div') })
-    pixiRenderer.update({ ...graph, options: { ...graph.options, animateNodePosition: false, animateNodeRadius: false, animateViewportPosition: false, animateViewportZoom: false } })
+  return (graph: {
+    nodes: N[];
+    edges: E[];
+    annotations?: Annotation[];
+    options?: Options;
+  }) => {
+    const pixiRenderer = new WebGL.InternalRenderer({
+      container: document.createElement("div"),
+    });
+    pixiRenderer.update({
+      ...graph,
+      options: {
+        ...graph.options,
+        animateNodePosition: false,
+        animateNodeRadius: false,
+        animateViewportPosition: false,
+        animateViewportZoom: false,
+      },
+    });
 
     return pixiRenderer
       .base64(graph.options?.resolution, graph.options?.mimetype)
       .then((dataURL) => {
-        pixiRenderer.delete()
-        return dataURL
-      })
-  }
-}
+        pixiRenderer.delete();
+        return dataURL;
+      });
+  };
+};
+
+export const BlobRenderer = <N extends Node, E extends Edge>() => {
+  return (graph: {
+    nodes: N[];
+    edges: E[];
+    annotations?: Annotation[];
+    options?: Exclude<Options, "mimetype">;
+  }) => {
+    const pixiRenderer = new WebGL.InternalRenderer({
+      container: document.createElement("div"),
+    });
+    pixiRenderer.update({
+      ...graph,
+      options: {
+        ...graph.options,
+        animateNodePosition: false,
+        animateNodeRadius: false,
+        animateViewportPosition: false,
+        animateViewportZoom: false,
+      },
+    });
+
+    return pixiRenderer.blob(graph.options?.resolution).then((dataURL) => {
+      pixiRenderer.delete();
+      return dataURL;
+    });
+  };
+};


### PR DESCRIPTION
Add `Image.BlobRenderer` alongside the existing `Image.Renderer`. The output is also a URL, but it's a `blob:` instead of a `data:`.